### PR TITLE
Printing size_t as %zd instead of %d to suppress warning

### DIFF
--- a/src/libmaxtouch/info_block.c
+++ b/src/libmaxtouch/info_block.c
@@ -71,7 +71,7 @@ static int calculate_crc(struct mxt_device *mxt, uint32_t read_crc,
   uint32_t calc_crc = 0; /* Checksum calculated by the driver code */
   uint16_t crc_byte_index = 0;
 
-  mxt_verb(mxt->ctx, "Calculating CRC over %d bytes", size);
+  mxt_verb(mxt->ctx, "Calculating CRC over %zd bytes", size);
 
   /* Call the CRC function crc24() iteratively to calculate the CRC,
    * passing it two characters at a time.  */


### PR DESCRIPTION
```
src/libmaxtouch/info_block.c: In function 'calculate_crc':
src/libmaxtouch/info_block.c:74:3: error: format '%d' expects argument of type 'int', but argument 3 has type 'size_t' [-Werror=format=]
   mxt_verb(mxt->ctx, "Calculating CRC over %d bytes", size);
   ^
cc1: all warnings being treated as errors
```

Suppressed the above warning (which may fail on some systems, depending on GCC configuration) concerning the printing specifier for the variable _size_ of type _size_t_. `%zd` should be used instead of `%d` in this instance.
