### PR TITLE
4-Byte Sized Fields of XCFG Are Now Supported 

### DIFF
--- a/src/libmaxtouch/config.c
+++ b/src/libmaxtouch/config.c
@@ -474,6 +474,12 @@ static int mxt_load_xcfg_file(struct mxt_device *mxt, const char *filename)
         *(mem + offset) = (char) data & 0xFF;
         *(mem + offset + 1) = (char) ((data >> 8) & 0xFF);
         break;
+      case 4:
+        *(mem + offset) = (char) data & 0xFF;
+        *(mem + offset + 1) = (char) ((data >> 8) & 0xFF);
+        *(mem + offset + 2) = (char) ((data >> 16) & 0xFF);
+        *(mem + offset + 3) = (char) ((data >> 24) & 0xFF);
+         break;
       default:
         mxt_err(mxt->ctx, "Only 16-bit / 8-bit config values supported!");
         ret = MXT_ERROR_FILE_FORMAT;


### PR DESCRIPTION
Because the size of T107.COMMSLENCMASK of mXT1666T2 v1.0.AA is 4-byte, we have to extend the size processing capability of mxt_load_xcfg_file() from 2-byte to 4-byte.
