### PR TITLE
Fix issues with self cap diagnostic data

### DIFF
--- a/src/libmaxtouch/i2c_dev/i2c_dev_device.c
+++ b/src/libmaxtouch/i2c_dev/i2c_dev_device.c
@@ -103,8 +103,6 @@ int i2c_dev_read_register(struct mxt_device *mxt, unsigned char *buf, int start_
   int ret;
   char register_buf[2];
 
-  mxt_dbg(mxt->ctx, "start_register:%d count:%d", start_register, count);
-
   ret = open_and_set_slave_address(mxt, &fd);
   if (ret)
     return ret;

--- a/src/libmaxtouch/libmaxtouch.c
+++ b/src/libmaxtouch/libmaxtouch.c
@@ -290,6 +290,9 @@ int mxt_read_register(struct mxt_device *mxt, uint8_t *buf,
 {
   int ret;
 
+  mxt_verb(mxt->ctx, "%s start_register:%d count:%d", __func__,
+           start_register, count);
+
   switch (mxt->conn->type) {
   case E_SYSFS:
     ret = sysfs_read_register(mxt, buf, start_register, count);
@@ -327,6 +330,9 @@ int mxt_write_register(struct mxt_device *mxt, uint8_t const *buf,
                        int start_register, int count)
 {
   int ret;
+
+  mxt_verb(mxt->ctx, "%s start_register:%d count:%d", __func__,
+           start_register, count);
 
   switch (mxt->conn->type) {
   case E_SYSFS:

--- a/src/mxt-app/diagnostic_data.c
+++ b/src/mxt-app/diagnostic_data.c
@@ -409,53 +409,19 @@ int mxt_debug_dump_initialise(struct t37_ctx *ctx)
   case SELF_CAP_REFS:
     ctx->self_cap = true;
 
-    if (id->family == 164) {
-      switch (id->variant) {
-      case 5:
-      case 9:
-        // mXT336T
-        ctx->y_size = 14;
-        ctx->x_size = 24;
-        break;
-
-      case 2:
-      case 7:
-        // mXT640T
-        ctx->y_size = 20;
-        ctx->x_size = 32;
-        break;
-
-      case 11:
-      case 12:
-        // mXT1066T
-        ctx->y_size = 26;
-        ctx->x_size = 41;
-        break;
-
-      case 3:
-      case 4:
-      case 13:
-      case 14:
-      case 15:
-      case 16:
-        // mXT2952T
-        ctx->y_size = 72;
-        ctx->x_size = 41;
-        break;
-
-      default:
-        goto self_cap_unsupported;
-      }
-    } else {
-      goto self_cap_unsupported;
+    if (id->family != 164) {
+      mxt_err(ctx->lc, "Self cap data not available");
+      return MXT_ERROR_NOT_SUPPORTED;
     }
 
     if (ctx->t111_instances == 0) {
-      goto self_cap_unsupported;
-    } else {
-      ctx->passes = ctx->t111_instances;
+      mxt_err(ctx->lc, "T111 not found");
+      return MXT_ERROR_OBJECT_NOT_FOUND;
     }
 
+    ctx->passes = ctx->t111_instances;
+    ctx->y_size = id->matrix_y_size;
+    ctx->x_size = id->matrix_x_size;
     ctx->data_values = ctx->y_size * ((ctx->x_size > ctx->y_size) ? 3 : 2);
     ctx->pages_per_pass = (ctx->data_values*2 +(ctx->page_size - 1)) /
                  ctx->page_size;
@@ -491,10 +457,6 @@ int mxt_debug_dump_initialise(struct t37_ctx *ctx)
   }
 
   return MXT_SUCCESS;
-
-self_cap_unsupported:
-  mxt_err(ctx->lc, "Self cap data not available");
-  return MXT_ERROR_NOT_SUPPORTED;
 }
 
 //******************************************************************************

--- a/src/mxt-app/mxt_app.h
+++ b/src/mxt-app/mxt_app.h
@@ -91,6 +91,8 @@ typedef enum mxt_app_cmd_t {
 /// \brief Signal handler semaphore
 volatile sig_atomic_t mxt_sigint_rx;
 
+struct t37_diagnostic_data;
+
 //******************************************************************************
 /// \brief T37 Diagnostic Data context object
 struct t37_ctx {
@@ -122,7 +124,7 @@ struct t37_ctx {
   int x_ptr;
   int y_ptr;
 
-  uint8_t *page_buf;
+  struct t37_diagnostic_data *page_buf;
   uint16_t *data_buf;
 
   FILE *hawkeye;

--- a/src/mxt-app/mxt_app.h
+++ b/src/mxt-app/mxt_app.h
@@ -104,9 +104,9 @@ struct t37_ctx {
   int x_size;
   int y_size;
 
-  int num_data_values;
-  int num_passes;
-  int pages;
+  int data_values;
+  int passes;
+  int pages_per_pass;
   int stripe_width;
   int stripe_starty;
   int stripe_endy;
@@ -124,7 +124,7 @@ struct t37_ctx {
   int x_ptr;
   int y_ptr;
 
-  struct t37_diagnostic_data *page_buf;
+  struct t37_diagnostic_data *t37_buf;
   uint16_t *data_buf;
 
   FILE *hawkeye;
@@ -144,7 +144,7 @@ int print_raw_messages(struct mxt_device *mxt, int timeout, uint16_t object_type
 int print_raw_messages_t44(struct mxt_device *mxt);
 void print_t6_status(uint8_t status);
 int mxt_self_cap_tune(struct mxt_device *mxt, mxt_app_cmd cmd);
-int mxt_debug_dump_frame(struct t37_ctx *ctx);
+int mxt_read_diagnostic_data_frame(struct t37_ctx *ctx);
 int mxt_debug_dump_initialise(struct t37_ctx *ctx);
 sig_atomic_t mxt_get_sigint_flag(void);
 int mxt_read_messages_sigint(struct mxt_device *mxt, int timeout_seconds, void *context, int (*msg_func)(struct mxt_device *mxt, uint8_t *msg, void *context, uint8_t size));


### PR DESCRIPTION
The diagnostic data algorithm was only parsing one type of diagnostic data, the order of the columns was generated wrong.

Update algorithm with reference to documentation. Tested on Pixel 2 chromebook, but needs independent verification.