### PR TITLE
Create m4 directory if it doesn't exist

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -3,6 +3,7 @@
 # Remove dependency cache otherwise file renames confuse autoconf
 find . -type d -name \.deps | xargs rm -rf
 
+[ -d m4 ] || mkdir m4
 autoreconf -v --install
 
 ./configure $@


### PR DESCRIPTION
aclocal 1.11 triggers a fatal error if this m4 directory doesn't exist.