### PR TITLE
Allow space separated entries for register bytes

### DIFF
--- a/src/libmaxtouch/utilfuncs.c
+++ b/src/libmaxtouch/utilfuncs.c
@@ -39,6 +39,7 @@
 #include "libmaxtouch.h"
 #include "utilfuncs.h"
 
+#define BUF_SIZE 1024
 #define BYTETOBINARYPATTERN "%d%d%d%d %d%d%d%d"
 #define BYTETOBINARY(byte)  \
   (byte & 0x80 ? 1 : 0), \
@@ -196,10 +197,10 @@ free:
 /// \return #mxt_rc
 int mxt_handle_write_cmd(struct mxt_device *mxt, const uint16_t type,
                          uint16_t count, const uint8_t inst, uint16_t address,
-                         unsigned char databuf[], const int buff_size, int argc,
-                         char *argv[])
+                         int argc, char *argv[])
 {
   uint16_t obj_addr = 0;
+  unsigned char databuf[BUF_SIZE];
   unsigned char *p_databuf = databuf;
   int ret = MXT_SUCCESS;
 
@@ -223,7 +224,7 @@ int mxt_handle_write_cmd(struct mxt_device *mxt, const uint16_t type,
 
   /* Parse unprocessed arguments */
   while (optind < argc) {
-    ret = mxt_convert_hex(argv[optind++], p_databuf, &count, buff_size - (p_databuf - databuf));
+    ret = mxt_convert_hex(argv[optind++], p_databuf, &count, sizeof(databuf) - (p_databuf - databuf));
 
     if (ret || count == 0) {
       fprintf(stderr, "Hex convert error\n");

--- a/src/libmaxtouch/utilfuncs.c
+++ b/src/libmaxtouch/utilfuncs.c
@@ -195,26 +195,23 @@ free:
 /// \brief Handles parsing of the write parameters
 /// \return #mxt_rc
 int mxt_handle_write_cmd(struct mxt_device *mxt, const uint16_t type,
-                         uint16_t count, struct libmaxtouch_ctx *ctx,
-                         const uint8_t inst, unsigned char databuf[],
-                         const int buff_size, int argc, char *argv[])
-
+                         uint16_t count, const uint8_t inst, uint16_t address,
+                         unsigned char databuf[], const int buff_size, int argc,
+                         char *argv[])
 {
-  uint16_t address = 0;
-  uint16_t obj_add = 0;
+  uint16_t obj_addr = 0;
   unsigned char *p_databuf = databuf;
   int ret = MXT_SUCCESS;
 
-
   if (type > 0) {
-    obj_add = mxt_get_object_address(mxt, type, inst);
-    if (obj_add == OBJECT_NOT_FOUND) {
+    obj_addr = mxt_get_object_address(mxt, type, inst);
+    if (obj_addr == OBJECT_NOT_FOUND) {
       fprintf(stderr, "No such object\n");
       return MXT_ERROR_OBJECT_NOT_FOUND;
     }
 
-    mxt_verb(ctx, "T%u address:%u offset:%u", type, obj_add, address);
-    address = obj_add + address;
+    mxt_verb(mxt->ctx, "T%u address:%u offset:%u", type, obj_addr, address);
+    address = obj_addr + address;
 
     if (count == 0) {
       count = mxt_get_object_size(mxt, type);
@@ -225,22 +222,21 @@ int mxt_handle_write_cmd(struct mxt_device *mxt, const uint16_t type,
   }
 
   /* Parse unprocessed arguments */
-  while (optind < argc && !ret) {
+  while (optind < argc) {
     ret = mxt_convert_hex(argv[optind++], p_databuf, &count, buff_size - (p_databuf - databuf));
 
     if (ret || count == 0) {
       fprintf(stderr, "Hex convert error\n");
-      ret = MXT_ERROR_BAD_INPUT;
+      return MXT_ERROR_BAD_INPUT;
     }
     p_databuf += count;
   }
 
-  if (!ret) {
-    ret = mxt_write_register(mxt, databuf, address, (p_databuf - databuf));
-    if (ret)
-      fprintf(stderr, "Write error\n");
-  }
-  return ret;
+  ret = mxt_write_register(mxt, databuf, address, (p_databuf - databuf));
+  if (ret)
+    fprintf(stderr, "Write error\n");
+
+  return MXT_SUCCESS;
 }
 
 //******************************************************************************

--- a/src/libmaxtouch/utilfuncs.c
+++ b/src/libmaxtouch/utilfuncs.c
@@ -281,13 +281,13 @@ int mxt_convert_hex(char *hex, unsigned char *databuf,
     if (lownibble == '\0' || lownibble == '\n')
       return MXT_ERROR_BAD_INPUT;
 
+    if (pos > buf_size)
+      return MXT_ERROR_NO_MEM;
+
     *(databuf + datapos) = (to_digit(highnibble) << 4)
                            | to_digit(lownibble);
     datapos++;
-
     pos += 2;
-    if (pos > buf_size)
-      return MXT_ERROR_NO_MEM;
   }
 
   *count = datapos;

--- a/src/libmaxtouch/utilfuncs.h
+++ b/src/libmaxtouch/utilfuncs.h
@@ -33,5 +33,6 @@
 void mxt_print_info_block(struct mxt_device *dev);
 const char *mxt_get_object_name(uint8_t objtype);
 int mxt_read_object(struct mxt_device *dev, uint16_t object_type, uint8_t instance, uint16_t offset, size_t count, bool format);
+int mxt_handle_write_cmd(struct mxt_device *mxt, const uint16_t type, uint16_t count, struct libmaxtouch_ctx *ctx, const uint8_t inst, unsigned char databuf[], const int buff_size, int argc, char *argv[]);
 int mxt_convert_hex(char *hex, unsigned char *databuf, uint16_t *count, unsigned int buf_size);
 int mxt_print_timestamp(FILE *stream, bool date);

--- a/src/libmaxtouch/utilfuncs.h
+++ b/src/libmaxtouch/utilfuncs.h
@@ -33,6 +33,6 @@
 void mxt_print_info_block(struct mxt_device *dev);
 const char *mxt_get_object_name(uint8_t objtype);
 int mxt_read_object(struct mxt_device *dev, uint16_t object_type, uint8_t instance, uint16_t offset, size_t count, bool format);
-int mxt_handle_write_cmd(struct mxt_device *mxt, const uint16_t type, uint16_t count, struct libmaxtouch_ctx *ctx, const uint8_t inst, unsigned char databuf[], const int buff_size, int argc, char *argv[]);
+int mxt_handle_write_cmd(struct mxt_device *mxt, const uint16_t type, uint16_t count, const uint8_t inst, uint16_t address, unsigned char databuf[], const int buff_size, int argc, char *argv[]);
 int mxt_convert_hex(char *hex, unsigned char *databuf, uint16_t *count, unsigned int buf_size);
 int mxt_print_timestamp(FILE *stream, bool date);

--- a/src/libmaxtouch/utilfuncs.h
+++ b/src/libmaxtouch/utilfuncs.h
@@ -33,6 +33,6 @@
 void mxt_print_info_block(struct mxt_device *dev);
 const char *mxt_get_object_name(uint8_t objtype);
 int mxt_read_object(struct mxt_device *dev, uint16_t object_type, uint8_t instance, uint16_t offset, size_t count, bool format);
-int mxt_handle_write_cmd(struct mxt_device *mxt, const uint16_t type, uint16_t count, const uint8_t inst, uint16_t address, unsigned char databuf[], const int buff_size, int argc, char *argv[]);
+int mxt_handle_write_cmd(struct mxt_device *mxt, const uint16_t type, uint16_t count, const uint8_t inst, uint16_t address, int argc, char *argv[]);
 int mxt_convert_hex(char *hex, unsigned char *databuf, uint16_t *count, unsigned int buf_size);
 int mxt_print_timestamp(FILE *stream, bool date);

--- a/src/mxt-app/mxt_app.c
+++ b/src/mxt-app/mxt_app.c
@@ -639,7 +639,7 @@ int main (int argc, char *argv[])
   case CMD_WRITE:
     mxt_verb(ctx, "Write command");
     ret = mxt_handle_write_cmd(mxt, object_type, count, instance, address,
-                               databuf, sizeof(databuf), argc, argv);
+                               argc, argv);
     if (ret == MXT_ERROR_BAD_INPUT)
       goto free;
     break;

--- a/src/mxt-app/mxt_app.c
+++ b/src/mxt-app/mxt_app.c
@@ -185,7 +185,7 @@ int main (int argc, char *argv[])
   bool format = false;
   uint16_t port = 4000;
   uint8_t t68_datatype = 1;
-  unsigned char databuf[BUF_SIZE];
+  unsigned char databuf;
   char strbuf2[BUF_SIZE];
   char strbuf[BUF_SIZE];
   strbuf[0] = '\0';
@@ -271,12 +271,12 @@ int main (int argc, char *argv[])
         if (cmd == CMD_NONE) {
           cmd = CMD_BACKUP;
           if (optarg) {
-            ret = mxt_convert_hex(optarg, &databuf[0], &count, sizeof(databuf));
+            ret = mxt_convert_hex(optarg, &databuf, &count, sizeof(databuf));
             if (ret || count == 0) {
               fprintf(stderr, "Hex convert error\n");
               ret = MXT_ERROR_BAD_INPUT;
             }
-            backup_cmd = databuf[0];
+            backup_cmd = databuf;
           }
         } else {
           print_usage(argv[0]);
@@ -560,12 +560,12 @@ int main (int argc, char *argv[])
     case 't':
       if (cmd == CMD_NONE) {
         if (optarg) {
-          ret = mxt_convert_hex(optarg, &databuf[0], &count, sizeof(databuf));
+          ret = mxt_convert_hex(optarg, &databuf, &count, sizeof(databuf));
           if (ret) {
             fprintf(stderr, "Hex convert error\n");
             ret = MXT_ERROR_BAD_INPUT;
           } else {
-            self_test_cmd = databuf[0];
+            self_test_cmd = databuf;
           }
         }
         cmd = CMD_TEST;

--- a/src/mxt-app/mxt_app.c
+++ b/src/mxt-app/mxt_app.c
@@ -638,8 +638,8 @@ int main (int argc, char *argv[])
   switch (cmd) {
   case CMD_WRITE:
     mxt_verb(ctx, "Write command");
-    ret = mxt_handle_write_cmd(mxt, object_type, count, ctx, instance, databuf,
-                               sizeof(databuf), argc, argv);
+    ret = mxt_handle_write_cmd(mxt, object_type, count, instance, address,
+                               databuf, sizeof(databuf), argc, argv);
     if (ret == MXT_ERROR_BAD_INPUT)
       goto free;
     break;


### PR DESCRIPTION
Update write command to allow spaces in between bytes.
In addition to this, other options can appear between and after bytes
without interfering with the parsing.

fixes #37 