### PR TITLE
Fix return value from to_digit

### DIFF
--- a/src/test/test_utilfuncs.c
+++ b/src/test/test_utilfuncs.c
@@ -75,4 +75,8 @@ void mxt_convert_hex_test(void **state)
   strcpy(hex, "0FAB");
   ret = mxt_convert_hex(hex, databuf, &count, 1);
   assert_int_equal(ret, MXT_ERROR_NO_MEM);
+
+  strcpy(hex, "0xA5");
+  ret = mxt_convert_hex(hex, databuf, &count, sizeof(databuf));
+  assert_int_equal(ret, MXT_ERROR_BAD_INPUT);
 }


### PR DESCRIPTION
to_digit now returns an mxt_rc enum value to provide feedback for
parsing, while the decimal value is passed in as an argument.
Unit tests updated to check for erroneous string input.