### PR TITLE
Introduce new command "--active-stylus-delta" to capture the deltas of Active Stylus

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,9 @@ deltas. Self capacitance measurements are only available on some devices.
 `--self-cap-refs`
 :   Capture self cap references.
 
+`--active-stylus-deltas`
+:   Capture active stylus deltas.
+
 # T68 SERIAL DATA COMMANDS
 
 `--t68-file *FILE*`

--- a/README.md
+++ b/README.md
@@ -230,6 +230,9 @@ deltas. Self capacitance measurements are only available on some devices.
 `--active-stylus-deltas`
 :   Capture active stylus deltas.
 
+`--active-stylus-refs`
+:   Capture active stylus references.
+
 # T68 SERIAL DATA COMMANDS
 
 `--t68-file *FILE*`

--- a/src/mxt-app/diagnostic_data.c
+++ b/src/mxt-app/diagnostic_data.c
@@ -81,6 +81,9 @@ static int get_objects_addr(struct t37_ctx *ctx)
   ctx->t111_instances = mxt_get_object_instances(ctx->mxt,
                         SPT_SELFCAPCONFIG_T111);
 
+  ctx->t107_instances = mxt_get_object_instances(ctx->mxt,
+                        PROCI_ACTIVESTYLUS_T107);
+
   return MXT_SUCCESS;
 }
 
@@ -214,6 +217,50 @@ static int mxt_generate_hawkeye_header(struct t37_ctx *ctx)
           return MXT_ERROR_IO;
       }
     }
+  } else if (ctx->active_stylus) {
+    for (pass = 0; pass < ctx->passes; pass++) {
+      const char * mode;
+      switch (ctx->mode) {
+      default:
+      case AST_DELTAS:
+        mode = "delta";
+        break;
+      }
+
+      for (y = 0; y < ctx->y_size; y++) {
+        int y_real;
+        const char* set;
+
+        if ( y < id->matrix_y_size) {
+          y_real = y;
+          set = "0";
+        } else {
+          y_real = y - id->matrix_y_size;
+          set = "1";
+        }
+        ret = fprintf(ctx->hawkeye, "AST_%s_Y%s_%d,", mode, set, y_real);
+        if (ret < 0)
+          return MXT_ERROR_IO;
+      }
+
+      for (x = 0; x < ctx->x_size; x++) {
+        int x_real;
+        const char* set;
+
+        if ( x < ctx->x_size/2) {
+          x_real = x;
+          set = "0"; // scan 0
+        } else {
+          x_real = x - ctx->x_size/2;
+          set = "1"; // scan 1
+        }
+
+        ret = fprintf(ctx->hawkeye, "AST_%s_X%s_%d,", mode, set, x_real);
+        if (ret < 0)
+          return MXT_ERROR_IO;
+      }
+    }
+
   } else {
     for (x = 0; x < ctx->x_size; x++) {
       for (y = 0; y < ctx->y_size; y++) {
@@ -318,7 +365,7 @@ static int mxt_hawkeye_output(struct t37_ctx *ctx)
   if (ret < 0)
     return MXT_ERROR_IO;
 
-  if (ctx->self_cap) {
+  if ((ctx->self_cap)||(ctx->active_stylus)) {
     for (pass = 0; pass < ctx->passes; pass++) {
       int pass_ofs = (ctx->y_size + ctx->x_size) * pass;
 
@@ -444,6 +491,29 @@ int mxt_debug_dump_initialise(struct t37_ctx *ctx)
 
     break;
 
+  case AST_DELTAS:
+    ctx->self_cap = false;
+    ctx->active_stylus = true;
+
+    if (id->family != 164) {
+      mxt_err(ctx->lc, "active stylus data not available");
+      return MXT_ERROR_NOT_SUPPORTED;
+    }
+
+    if (ctx->t107_instances == 0) {
+      mxt_err(ctx->lc, "T107 not found");
+      return MXT_ERROR_OBJECT_NOT_FOUND;
+    }
+
+    // read Ymax Y values, plus Ymax or 2Ymax X values
+    ctx->passes = ctx->t107_instances;
+    ctx->y_size = 2 * id->matrix_y_size;    // two scans per axis
+    ctx->x_size = ctx->y_size * ((id->matrix_x_size > ctx->y_size) ? 2 : 1);
+    ctx->data_values = (ctx->y_size + ctx->x_size) * ctx->passes;
+    ctx->pages_per_pass = ((ctx->y_size + ctx->x_size)*sizeof(uint16_t) +(ctx->page_size - 1)) /
+                          ctx->page_size;
+    break;
+
   default:
     mxt_err(ctx->lc, "Unsupported mode %02X", ctx->mode);
     return MXT_INTERNAL_ERROR;
@@ -530,6 +600,14 @@ static int mxt_read_diagnostic_data_self_cap(struct t37_ctx* ctx)
 }
 
 //******************************************************************************
+/// \brief Read one frame of diagnostic data
+/// \return #mxt_rc
+static int mxt_read_diagnostic_data_ast(struct t37_ctx* ctx)
+{
+  return mxt_read_diagnostic_data_self_cap(ctx);
+}
+
+//******************************************************************************
 /// \brief Retrieve data from the T37 Diagnostic Data object
 /// \return #mxt_rc
 int mxt_debug_dump(struct mxt_device *mxt, int mode, const char *csv_file,
@@ -570,10 +648,13 @@ int mxt_debug_dump(struct mxt_device *mxt, int mode, const char *csv_file,
   t1 = time(NULL);
 
   for (ctx.frame = 1; ctx.frame <= frames; ctx.frame++) {
-    if (!ctx.self_cap) {
-      ret = mxt_read_diagnostic_data_frame(&ctx);
-    } else {
+    if (ctx.self_cap) {
       ret = mxt_read_diagnostic_data_self_cap(&ctx);
+    }
+    else if (ctx.active_stylus){
+      ret = mxt_read_diagnostic_data_ast(&ctx);
+    } else {
+      ret = mxt_read_diagnostic_data_frame(&ctx);
     }
     if (ret)
       goto close;

--- a/src/mxt-app/mxt_app.c
+++ b/src/mxt-app/mxt_app.c
@@ -146,6 +146,7 @@ static void print_usage(char *prog_name)
           "  --self-cap-signals         : capture self cap signals\n"
           "  --self-cap-deltas          : capture self cap deltas\n"
           "  --self-cap-refs            : capture self cap references\n"
+          "  --active-stylus-deltas     : capture active stylus deltas\n"
           "\n"
           "Device connection options:\n"
           "  -q [--query]               : scan for devices\n"
@@ -229,6 +230,7 @@ int main (int argc, char *argv[])
       {"self-cap-signals", no_argument,       0, 0},
       {"self-cap-deltas",  no_argument,       0, 0},
       {"self-cap-refs",    no_argument,       0, 0},
+      {"active-stylus-deltas",    no_argument,       0, 0},
       {"bridge-server",    no_argument,       0, 'S'},
       {"test",             optional_argument, 0, 't'},
       {"type",             required_argument, 0, 'T'},
@@ -379,6 +381,8 @@ int main (int argc, char *argv[])
         t37_mode = SELF_CAP_REFS;
       } else if (!strcmp(long_options[option_index].name, "self-cap-deltas")) {
         t37_mode = SELF_CAP_DELTAS;
+      } else if (!strcmp(long_options[option_index].name, "active-stylus-deltas")) {
+        t37_mode = AST_DELTAS;
       } else if (!strcmp(long_options[option_index].name, "version")) {
         printf("mxt-app %s%s\n", MXT_VERSION, ENABLE_DEBUG ? " DEBUG":"");
         return MXT_SUCCESS;

--- a/src/mxt-app/mxt_app.c
+++ b/src/mxt-app/mxt_app.c
@@ -147,6 +147,7 @@ static void print_usage(char *prog_name)
           "  --self-cap-deltas          : capture self cap deltas\n"
           "  --self-cap-refs            : capture self cap references\n"
           "  --active-stylus-deltas     : capture active stylus deltas\n"
+          "  --active-stylus-refs       : capture active stylus references\n"
           "\n"
           "Device connection options:\n"
           "  -q [--query]               : scan for devices\n"
@@ -230,7 +231,8 @@ int main (int argc, char *argv[])
       {"self-cap-signals", no_argument,       0, 0},
       {"self-cap-deltas",  no_argument,       0, 0},
       {"self-cap-refs",    no_argument,       0, 0},
-      {"active-stylus-deltas",    no_argument,       0, 0},
+      {"active-stylus-deltas",  no_argument,       0, 0},
+      {"active-stylus-refs",    no_argument,       0, 0},
       {"bridge-server",    no_argument,       0, 'S'},
       {"test",             optional_argument, 0, 't'},
       {"type",             required_argument, 0, 'T'},
@@ -383,6 +385,8 @@ int main (int argc, char *argv[])
         t37_mode = SELF_CAP_DELTAS;
       } else if (!strcmp(long_options[option_index].name, "active-stylus-deltas")) {
         t37_mode = AST_DELTAS;
+      } else if (!strcmp(long_options[option_index].name, "active-stylus-refs")) {
+        t37_mode = AST_REFS;
       } else if (!strcmp(long_options[option_index].name, "version")) {
         printf("mxt-app %s%s\n", MXT_VERSION, ENABLE_DEBUG ? " DEBUG":"");
         return MXT_SUCCESS;

--- a/src/mxt-app/mxt_app.h
+++ b/src/mxt-app/mxt_app.h
@@ -41,6 +41,7 @@
 #define SELF_CAP_SIGNALS  0xF5
 #define SELF_CAP_DELTAS   0xF7
 #define SELF_CAP_REFS     0xF8
+#define AST_DELTAS        0xFB
 
 /* T25 Self Test Commands */
 #define SELF_TEST_ANALOG       0x01
@@ -100,6 +101,7 @@ struct t37_ctx {
   struct libmaxtouch_ctx *lc;
 
   bool self_cap;
+  bool active_stylus;
 
   int x_size;
   int y_size;
@@ -117,6 +119,7 @@ struct t37_ctx {
   int t37_addr;
   int t37_size;
   uint8_t t111_instances;
+  uint8_t t107_instances;
 
   uint16_t frame;
   int pass;

--- a/src/mxt-app/mxt_app.h
+++ b/src/mxt-app/mxt_app.h
@@ -42,6 +42,7 @@
 #define SELF_CAP_DELTAS   0xF7
 #define SELF_CAP_REFS     0xF8
 #define AST_DELTAS        0xFB
+#define AST_REFS          0xFC
 
 /* T25 Self Test Commands */
 #define SELF_TEST_ANALOG       0x01


### PR DESCRIPTION
Updated from https://github.com/atmel-maxtouch/mxt-app/pull/38, removing static function mxt_debug_insert_data_ast, which was preventing compilation.