### PR TITLE
Add --block-size option to mxt-app

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ by Atmel under NDA.
 `--version`
 :   print version of mxt-app.
 
+`--block-size *BLOCKSIZE*`
+:   Sets the i2c block size.
+
 # CONFIGURATION FILE COMMANDS
 
 `--load *FILE*`

--- a/src/libmaxtouch/i2c_dev/i2c_dev_device.c
+++ b/src/libmaxtouch/i2c_dev/i2c_dev_device.c
@@ -47,8 +47,6 @@ struct mxt_conn_info;
 /* Deep sleep retry delay 25 ms */
 #define I2C_RETRY_DELAY 25000
 
-#define I2C_DEV_MAX_BLOCK 255
-
 //******************************************************************************
 /// \brief  Register i2c-dev device
 /// \return #mxt_rc
@@ -100,14 +98,14 @@ static int open_and_set_slave_address(struct mxt_device *mxt, int *fd_out)
 /// \brief  Read register from MXT chip
 /// \return #mxt_rc
 int i2c_dev_read_register(struct mxt_device *mxt, unsigned char *buf,
-                          int start_register, size_t count, size_t *bytes_read)
+                          int start_register, int count, size_t *bytes_read)
 {
   int fd = -ENODEV;
   int ret;
   char register_buf[2];
 
-  if (count > I2C_DEV_MAX_BLOCK)
-    count = I2C_DEV_MAX_BLOCK;
+  if (count > mxt->ctx->i2c_block_size)
+    count = mxt->ctx->i2c_block_size;
 
   ret = open_and_set_slave_address(mxt, &fd);
   if (ret)
@@ -220,8 +218,8 @@ int i2c_dev_bootloader_write(struct mxt_device *mxt, unsigned char const *buf,
   int fd = -ENODEV;
   int ret;
 
-  if (count > I2C_DEV_MAX_BLOCK)
-    count = I2C_DEV_MAX_BLOCK;
+  if (count > mxt->ctx->i2c_block_size)
+    count = mxt->ctx->i2c_block_size;
 
   ret = open_and_set_slave_address(mxt, &fd);
   if (ret)

--- a/src/libmaxtouch/i2c_dev/i2c_dev_device.h
+++ b/src/libmaxtouch/i2c_dev/i2c_dev_device.h
@@ -28,6 +28,8 @@
 // EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //------------------------------------------------------------------------------
 
+#define I2C_DEV_MAX_BLOCK 255
+
 //******************************************************************************
 /// \brief Device information for i2c-dev backend
 struct i2c_dev_conn_info {
@@ -42,7 +44,7 @@ struct i2c_dev_device {
 
 int i2c_dev_open(struct mxt_device *mxt);
 void i2c_dev_release(struct mxt_device *mxt);
-int i2c_dev_read_register(struct mxt_device *mxt, unsigned char *buf, int start_register, size_t count, size_t *bytes_transferred);
+int i2c_dev_read_register(struct mxt_device *mxt, unsigned char *buf, int start_register, int count, size_t *bytes_transferred);
 int i2c_dev_write_register(struct mxt_device *mxt, unsigned char const *buf, int start_register, size_t count);
 int i2c_dev_bootloader_read(struct mxt_device *mxt, unsigned char *buf, int count);
 int i2c_dev_bootloader_write(struct mxt_device *mxt, unsigned char const *buf, int count, size_t *bytes_transferred);

--- a/src/libmaxtouch/libmaxtouch.c
+++ b/src/libmaxtouch/libmaxtouch.c
@@ -52,6 +52,7 @@ int mxt_new(struct libmaxtouch_ctx **ctx)
   new_ctx->log_level = LOG_ERROR;
   new_ctx->query = false;
   new_ctx->log_fn = mxt_log_stderr;
+  new_ctx->i2c_block_size = I2C_DEV_MAX_BLOCK;
 
   *ctx = new_ctx;
 

--- a/src/libmaxtouch/libmaxtouch.h
+++ b/src/libmaxtouch/libmaxtouch.h
@@ -131,6 +131,7 @@ struct libmaxtouch_ctx {
   bool query;
   int scan_count;
   enum mxt_log_level log_level;
+  int i2c_block_size;
 
   void (*log_fn)(struct libmaxtouch_ctx *ctx, enum mxt_log_level level,
                  const char *format, va_list args);


### PR DESCRIPTION
Adds the --block-size option to mxt-app, which provides the I2C block
size information.
Also adds the block size value to the i2c_dev_device, rather than using
the defined value in all instances.

See https://github.com/atmel-maxtouch/mxt-app/issues/45  for original requirements.