### PR TITLE
Fix ret type in read_boolean_file

### DIFF
--- a/src/libmaxtouch/sysfs/sysfs_device.c
+++ b/src/libmaxtouch/sysfs/sysfs_device.c
@@ -483,7 +483,7 @@ static int read_boolean_file(struct mxt_device *mxt, char *filename,
 {
   FILE *file;
   char val;
-  bool ret;
+  int ret;
 
   file = fopen(filename, "r");
   if (!file) {


### PR DESCRIPTION
ret is boolean so the comparison (ret < 0) will always evaluate to false.
Change it to the proper type, int

Signed-off-by: Alexandre Belloni <alexandre.belloni@free-electrons.com>