### PR TITLE
Add .empty in m4 folder and remove mkdir in autogen

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -3,7 +3,6 @@
 # Remove dependency cache otherwise file renames confuse autoconf
 find . -type d -name \.deps | xargs rm -rf
 
-[ -d m4 ] || mkdir m4
 autoreconf -v --install
 
 ./configure $@


### PR DESCRIPTION
Buildroot does not execute the autogen.sh so we cannot build it with it. With the .empty file in the m4 folder the folder is always created.