### PR TITLE
Problem Report: Uninitialized variable being used and may cause incorrect content been debug dumped.

### DIFF
--- a/src/mxt-app/diagnostic_data.c
+++ b/src/mxt-app/diagnostic_data.c
@@ -434,6 +434,8 @@ int mxt_debug_dump_initialise(struct t37_ctx *ctx)
   struct mxt_id_info *id = ctx->mxt->info.id;
   int ret;
 
+  ctx->active_stylus = false;
+
   ret = get_objects_addr(ctx);
   if (ret) {
     mxt_err(ctx->lc, "Failed to get object information");


### PR DESCRIPTION
TKT-016076: BUG_FIXED - This is a bug fix of my commit a46f80ec20f69a9f801b6ad0395377e46bdc1535. Because in that commit, the variable ctx->active_stylus may be used without been initialized, and hence can generate random behavior. For example, with command "./mxt-app --frames 2 --references --debug-dump ref.csv", but the output ref.csv may be with active stylus headers incorrectly generated, it shall be mutual cap reference headers.