### PR TITLE
Fix #include typo

### DIFF
--- a/src/test/run_unit_tests.c
+++ b/src/test/run_unit_tests.c
@@ -37,7 +37,7 @@
 #include <stdbool.h>
 #include <signal.h>
  
-+include "mxt-app/mxt_app.h"
+#include "mxt-app/mxt_app.h"
 #include "run_unit_tests.h"
 
 	


### PR DESCRIPTION
Typoed + instead of # in run_unit_tests.c.