### PR TITLE
Ensure i2c_adapter var is set properly in bootloader

### DIFF
--- a/src/mxt-app/bootloader.c
+++ b/src/mxt-app/bootloader.c
@@ -452,6 +452,7 @@ static int mxt_bootloader_init_chip(struct flash_context *fw)
 #endif
 
   case E_I2C_DEV:
+    fw->i2c_adapter = fw->conn->i2c_dev.adapter;
     if (fw->conn->i2c_dev.address < 0x4a) {
       mxt_info(fw->ctx, "Using bootloader address");
       fw->appmode_address = -1;
@@ -528,6 +529,7 @@ static int mxt_enter_bootloader_mode(struct flash_context *fw)
   }
 
   if (fw->conn->type == E_I2C_DEV) {
+    fw->i2c_adapter = fw->conn->i2c_dev.adapter;
     fw->appmode_address = fw->conn->i2c_dev.address;
 
     fw->conn->i2c_dev.address = lookup_bootloader_addr(fw, fw->appmode_address);


### PR DESCRIPTION
After flashing and returning to app mode, the connection is released
(mxt_unref_conn() + mxt_free_device()) and recreated. During
initializing new 'struct mxt_conn_info', the 'i2c_adapter' value from
'struct flash_context' is used to set i2c bus:
  new_conn->i2c_dev.adapter = fw.i2c_adapter;

The i2c_adapter variable is always 0, when device was specified by i2c
bus and address from the parameters.

Signed-off-by: Ondrej Pik <ondrej@amarulasolutions.com>