### PR TITLE
Pz/add support for TNxPB-004

### DIFF
--- a/src/libmaxtouch/usb/usb_device.h
+++ b/src/libmaxtouch/usb/usb_device.h
@@ -58,6 +58,7 @@ struct usb_device {
   libusb_device_handle *handle;
   struct libusb_device_descriptor desc;
   int ep1_in_max_packet_size;
+  bool ep1_in_use_max_packet_size;
   int request_ep;
   int interface;
   bool bootloader;

--- a/src/libmaxtouch/usb/usb_device.h
+++ b/src/libmaxtouch/usb/usb_device.h
@@ -58,6 +58,7 @@ struct usb_device {
   libusb_device_handle *handle;
   struct libusb_device_descriptor desc;
   int ep1_in_max_packet_size;
+  int request_ep;
   int interface;
   bool bootloader;
   int report_id;


### PR DESCRIPTION
This enables mxt-app functionality for the TouchNetix Device PB-004.

- Full max package size must be transferred.
- Interrupt endpoint must be used instead of bulk endpoint.
- Product IDs must match (there would be more but 0x2f02 is the current one used)
