### PR TITLE
Make mxt_sigint_rx extern in header file

### DIFF
--- a/src/mxt-app/mxt_app.h
+++ b/src/mxt-app/mxt_app.h
@@ -113,7 +113,7 @@ typedef enum mxt_app_cmd_t {
 
 //******************************************************************************
 /// \brief Signal handler semaphore
-volatile sig_atomic_t mxt_sigint_rx;
+extern volatile sig_atomic_t mxt_sigint_rx;
 
 struct t37_diagnostic_data;
 struct mxt_conn_info;


### PR DESCRIPTION
Its defined in src/mxt-app/signal.c like

volatile sig_atomic_t mxt_sigint_rx = 0;

Therefore we do not need another definition in header file, this fixes
the build with -fno-common ( which is default with gcc 10+)

Signed-off-by: Khem Raj <raj.khem@gmail.com>