### PR TITLE
Removed code to disable T100 in broken-line and sensor-varant test

### DIFF
--- a/src/mxt-app/diagnostic_data.c
+++ b/src/mxt-app/diagnostic_data.c
@@ -1592,12 +1592,6 @@ int mxt_disable_touch(struct mxt_device *mxt)
     mxt_dbg(mxt->ctx, "Disabling TOUCH_MULTITOUCHSCREEN_T9 instance 1");
   }
 
-  addr = mxt_get_object_address(mxt, TOUCH_MULTITOUCHSCREEN_T100, 0);
-  if (!(addr == OBJECT_NOT_FOUND)) {
-    mxt_write_register(mxt, &disable, addr, sizeof(disable));
-    mxt_dbg(mxt->ctx, "Disabling TOUCH_MULTITOUCHSCREEN_T100");
-  }
-
   return MXT_SUCCESS;
 }
 


### PR DESCRIPTION
Remove code to disable T100 in broken-line and sensor-variant test.  Causing T6 return message to set CFGERR bit in status byte instead of CAL bit.