### PR TITLE
Add SPI handling to mxt-app

### DIFF
--- a/src/libmaxtouch/config.c
+++ b/src/libmaxtouch/config.c
@@ -211,6 +211,10 @@ static int mxt_write_device_config(struct mxt_device *mxt,
     if (mxt->conn->type == E_I2C_DEV)
       mxt->mxt_crc.config_triggered = true;
 
+    if (mxt->conn->type == E_SYSFS_SPI) {
+      err = sysfs_set_debug_irq(mxt, false);
+    }
+
     ret = mxt_write_object_config(mxt, objcfg);
     if (ret == MXT_ERROR_OBJECT_NOT_FOUND)
       mxt_warn(mxt->ctx, "T%d not present", objcfg->type);
@@ -219,10 +223,13 @@ static int mxt_write_device_config(struct mxt_device *mxt,
     else if (ret){
       mxt->mxt_crc.config_triggered = false;
 
+    if (mxt->conn->type == E_SYSFS_SPI)
+      err = sysfs_set_debug_irq(mxt, true);
+
       if (mxt->conn->type == E_I2C_DEV  && mxt->debug_fs.enabled == true) {
       	/* Allow messages to be read thru mxt-app */
         err = debugfs_set_irq(mxt, true);
-      } else if (mxt->conn->type == E_SYSFS){
+      } else if (mxt->conn->type == E_SYSFS_I2C){
         if (mxt->mxt_crc.crc_enabled == true)
           err = sysfs_set_debug_irq(mxt, true);
       }
@@ -237,10 +244,13 @@ static int mxt_write_device_config(struct mxt_device *mxt,
   
   if (mxt->conn->type == E_I2C_DEV && mxt->debug_fs.enabled == true){
     err = debugfs_set_irq(mxt, true);
-  } else if (mxt->conn->type == E_SYSFS){
+  } else if (mxt->conn->type == E_SYSFS_I2C){
       if (mxt->mxt_crc.crc_enabled == true)
         err = sysfs_set_debug_irq(mxt, true);
   }
+
+  if (mxt->conn->type == E_SYSFS_SPI)
+      err = sysfs_set_debug_irq(mxt, true);
 
   return MXT_SUCCESS;
 }

--- a/src/libmaxtouch/libmaxtouch.h
+++ b/src/libmaxtouch/libmaxtouch.h
@@ -75,7 +75,7 @@ struct mxt_conn_info;
 #define MXT_CALIBRATE_TIMEOUT 10
 
 /* Soft reset time, no i2c activity */
-#define MXT_SOFT_RESET_TIME  1000000
+#define MXT_SOFT_RESET_TIME  999999
 
 //******************************************************************************
 /// \brief Return codes
@@ -129,12 +129,14 @@ enum mxt_rc {
 //******************************************************************************
 /// \brief Device connection type
 enum mxt_device_type {
-  E_SYSFS,
-#ifdef HAVE_LIBUSB
+  E_SYSFS_I2C,
+  E_SYSFS_SPI,
+  #ifdef HAVE_LIBUSB
   E_USB,
 #endif
   E_I2C_DEV,
   E_HIDRAW,
+  E_SPI,
 };
 
 //******************************************************************************
@@ -193,6 +195,7 @@ struct mxt_device {
 
 int mxt_new(struct libmaxtouch_ctx **ctx);
 int mxt_free(struct libmaxtouch_ctx *ctx);
+void msleep(int tms);
 int mxt_scan(struct libmaxtouch_ctx *ctx, struct mxt_conn_info **conn, bool query);
 int mxt_new_conn(struct mxt_conn_info **conn, enum mxt_device_type type);
 struct mxt_conn_info *mxt_ref_conn(struct mxt_conn_info *conn);
@@ -207,6 +210,8 @@ int mxt_write_register(struct mxt_device *mxt, uint8_t const *buf, int start_reg
 int mxt_write_bytes(struct mxt_device *mxt, uint8_t const *buf, int start_register, size_t count);
 int sysfs_get_tx_seq_num(struct mxt_device *mxt, uint16_t *value);
 int sysfs_set_tx_seq_num(struct mxt_device *mxt, uint8_t value);
+int sysfs_set_bootloader(struct mxt_device *mxt, bool value);
+int sysfs_get_bootloader(struct mxt_device *mxt, bool *value);
 int sysfs_get_debug_ha(struct mxt_device *mxt, bool *value);
 int mxt_set_debug(struct mxt_device *mxt, bool debug_state);
 int mxt_get_debug(struct mxt_device *mxt, bool *value);

--- a/src/libmaxtouch/msg.c
+++ b/src/libmaxtouch/msg.c
@@ -286,6 +286,9 @@ uint32_t mxt_get_config_crc(struct mxt_device *mxt)
       mxt_dbg(mxt->ctx, "Could not disable IRQ");
   }
 
+  // May need to be increased if more reports enabled
+  msleep(100);  //Added delay for SPI transfers
+
   return checksum;
 }
 

--- a/src/libmaxtouch/sysfs/sysfs_device.h
+++ b/src/libmaxtouch/sysfs/sysfs_device.h
@@ -35,6 +35,10 @@ struct dmesg_item;
 struct sysfs_conn_info {
   char *path;
   bool acpi;
+  int spi_cs;
+  int spi_bus;
+  bool spi_found;
+  bool i2c_found;
 };
 
 //******************************************************************************
@@ -52,6 +56,8 @@ struct sysfs_device {
   int debug_msg_buf_size;
   int debug_notify_fd;
   size_t debug_v2_size;
+  bool b_i2c_device;
+  bool b_spi_device;
 
   int dmesg_count;
   struct dmesg_item *dmesg_head;
@@ -62,10 +68,13 @@ struct sysfs_device {
 };
 
 int sysfs_scan(struct libmaxtouch_ctx *ctx, struct mxt_conn_info **conn);
+int sysfs_spi_scan(struct libmaxtouch_ctx *ctx, struct mxt_conn_info **conn);
 int sysfs_open(struct mxt_device *mxt);
 void sysfs_release(struct mxt_device *mxt);
 int sysfs_new_device(struct libmaxtouch_ctx *ctx, struct mxt_conn_info **conn, const char *dirname);
 int sysfs_read_register(struct mxt_device *mxt, unsigned char *buf, int start_register, size_t count, size_t *bytes_transferred);
+int sysfs_bootloader_read(struct mxt_device *mxt, unsigned char *buf, int count);
+int sysfs_bootloader_write(struct mxt_device *mxt, unsigned const char *buf, int count);
 int sysfs_write_register(struct mxt_device *mxt, unsigned char const *buf, int start_register, size_t count);
 int sysfs_set_debug(struct mxt_device *mxt, bool debug_state);
 int sysfs_get_debug(struct mxt_device *mxt, bool *value);

--- a/src/mxt-app/bridge.c
+++ b/src/mxt-app/bridge.c
@@ -358,7 +358,7 @@ static int bridge_info_connection(struct mxt_device *mxt, struct bridge_context 
     break;
 #endif
 
-  case E_SYSFS:
+  case E_SYSFS_I2C:
     ret = sysfs_get_i2c_address(mxt->ctx, mxt->conn,
                                 &i2c_adapter, &i2c_address);
     if (ret)

--- a/src/mxt-app/menu.c
+++ b/src/mxt-app/menu.c
@@ -94,7 +94,7 @@ static void flash_firmware_command(struct mxt_device *mxt)
   char fw_file[255];
   struct mxt_conn_info *conn = NULL;
 
-  /* Save config file */
+  /* Enter firmware file */
   printf("Give firmware .enc file name: ");
   if (scanf("%255s", fw_file) != 1) {
     printf("Input parse error\n");
@@ -333,7 +333,7 @@ int mxt_menu(struct mxt_device *mxt)
   bool exit_loop = false;
   int ret;
 
-  printf("Command line tool for Atmel maXTouch chips version: %s\n\n",
+  printf("\nCommand line tool for Atmel maXTouch chips version: %s\n\n",
          MXT_VERSION);
 
   while(!exit_loop) {


### PR DESCRIPTION
Add SPI handing to mxt-app through sysfs attributes.
Backwards compatible with I2C driver