### PR TITLE
increase max buffer line size

### DIFF
--- a/src/mxt-app/bridge.c
+++ b/src/mxt-app/bridge.c
@@ -50,7 +50,7 @@
 #include "mxt_app.h"
 #include "buffer.h"
 
-#define MAX_LINESIZE 10000
+#define MAX_LINESIZE 12000
 
 struct bridge_context {
   int sockfd;


### PR DESCRIPTION
MAX limit for string in line buffer increased from 10000 to 12000 to accommodate devices with larger configurations.