### PR TITLE
Fix for bridge board flashing

### DIFF
--- a/src/libmaxtouch/libmaxtouch.h
+++ b/src/libmaxtouch/libmaxtouch.h
@@ -131,7 +131,7 @@ enum mxt_rc {
 enum mxt_device_type {
   E_SYSFS_I2C,
   E_SYSFS_SPI,
-  #ifdef HAVE_LIBUSB
+#ifdef HAVE_LIBUSB
   E_USB,
 #endif
   E_I2C_DEV,

--- a/src/libmaxtouch/usb/usb_device.h
+++ b/src/libmaxtouch/usb/usb_device.h
@@ -61,6 +61,8 @@ struct usb_device {
   int interface;
   bool bootloader;
   int report_id;
+  int address;
+  bool sent_btlr_cmd;
 };
 
 int usb_scan(struct libmaxtouch_ctx *ctx, struct mxt_conn_info **conn);

--- a/src/mxt-app/bootloader.c
+++ b/src/mxt-app/bootloader.c
@@ -567,8 +567,6 @@ static int mxt_enter_bootloader_mode(struct flash_context *fw)
       ret = sysfs_set_bootloader(fw->mxt, true);
   }
 
-  mxt_free_device(fw->mxt);
-
   return MXT_SUCCESS;
 }
 
@@ -628,10 +626,12 @@ int mxt_flash_firmware(struct libmaxtouch_ctx *ctx,
     }
   }
 
-  ret = mxt_new_device(fw.ctx, fw.conn, &fw.mxt);
-  if (ret) {
-    mxt_info(fw.ctx, "Could not initialise chip");
-    return ret;
+  if (fw.mxt->conn->type == E_SYSFS_SPI) {
+    ret = mxt_new_device(fw.ctx, fw.conn, &fw.mxt);
+   if (ret) {
+      mxt_info(fw.ctx, "Could not initialise chip");
+      return ret;
+    }
   }
 
   ret = send_frames(&fw);


### PR DESCRIPTION
-- Fix flashing using bridge board
-- Bridge board tries to auto find I2C address resulting in exiting bootloader mode too early
-- Assign bootloader address based on app slave_address
-- maXTouch device is not assigned same device # on reset
-- Removed usb_device variable check after reset