### PR TITLE
I2cdev reset fix

### DIFF
--- a/src/libmaxtouch/info_block.c
+++ b/src/libmaxtouch/info_block.c
@@ -104,10 +104,11 @@ int mxt_read_info_block(struct mxt_device *mxt)
 {
   uint32_t calc_crc;
   bool crc_flag = false;
-  int ret;
+  int ret = 0;
 
   /* Read the ID Information from the chip */
   uint8_t *info_blk = (uint8_t *)calloc(1, sizeof(struct mxt_id_info));
+
   if (info_blk == NULL) {
     mxt_err(mxt->ctx, "Memory allocation failure");
     return MXT_ERROR_NO_MEM;
@@ -118,20 +119,19 @@ int mxt_read_info_block(struct mxt_device *mxt)
     ret = debugfs_scan(mxt);
 
     if (ret == MXT_SUCCESS) {
-      ret = debugfs_open(mxt);
 
+      ret = debugfs_open(mxt);
       if (ret)
         mxt_err(mxt->ctx, "Could not register debugfs interface");
+      else
+        mxt->debug_fs.enabled = true;
 
-        ret = debugfs_get_crc_enabled(mxt, &crc_flag);
-      
+      ret = debugfs_get_crc_enabled(mxt, &crc_flag);
       if (ret)
-        mxt_err(mxt->ctx, "Coud not get crc_enabled flag");
+        mxt_err(mxt->ctx, "Could not get crc_enabled flag");
 
       if (crc_flag)
         mxt->mxt_crc.crc_enabled = true;
-
-      mxt->debug_fs.enabled = true;
 
     } else {
       mxt_dbg(mxt->ctx, "Debugfs attributes not found");
@@ -272,8 +272,6 @@ void mxt_display_chip_info(struct mxt_device *mxt)
   struct mxt_id_info *id = mxt->info.id;
   uint16_t t144_addr = 0x0000;
   int i;
-
-  mxt->mxt_crc.crc_enabled = false;
 
   mxt_get_firmware_version(mxt, (char *)&firmware_version);
 

--- a/src/libmaxtouch/libmaxtouch.c
+++ b/src/libmaxtouch/libmaxtouch.c
@@ -663,11 +663,11 @@ static int mxt_send_reset_command(struct mxt_device *mxt, bool bootloader_mode, 
         err = debugfs_set_tx_seq_num(mxt, 0x00);
         if (err)
           mxt_dbg(mxt->ctx, "Failed to set tx seq numer\n");
+      }
 
-        err = debugfs_set_irq(mxt, true);
+      err = debugfs_set_irq(mxt, true);
         if (err)
           mxt_dbg(mxt->ctx, "Could not enable IRQ");
-      }
     }
 
     mxt->mxt_crc.reset_triggered = false;

--- a/src/libmaxtouch/libmaxtouch.c
+++ b/src/libmaxtouch/libmaxtouch.c
@@ -617,15 +617,14 @@ static int mxt_send_reset_command(struct mxt_device *mxt, bool bootloader_mode, 
 
   mxt->mxt_crc.reset_triggered = true;
 
+  if (mxt->conn->type == E_I2C_DEV && mxt->debug_fs.enabled == true) {
+    err = debugfs_set_irq(mxt, false);
+    if (err)
+      mxt_dbg(mxt->ctx, "Could not disable IRQ");
+  }
+
   /* The value written determines which mode the chip will boot into */
   if (bootloader_mode) {
-
-    if (mxt->conn->type == E_I2C_DEV && mxt->debug_fs.enabled == true) {
-      err = debugfs_set_irq(mxt, false);
-
-      if (err)
-        mxt_dbg(mxt->ctx, "Could not disable IRQ");
-    }
 
     mxt_info(mxt->ctx, "Resetting in bootloader mode");
    
@@ -634,30 +633,23 @@ static int mxt_send_reset_command(struct mxt_device *mxt, bool bootloader_mode, 
     ret = mxt_write_register(mxt, &write_value, t6_addr + MXT_T6_RESET_OFFSET, 1);
 
   } else {
-      mxt_info(mxt->ctx, "Sending reset command");
 
-      /* Possible error out, new sysfs attr */
-      err = sysfs_reset_chip(mxt, true);
+      if (mxt->conn->type != E_I2C_DEV)
+        err = sysfs_reset_chip(mxt);
 
-      /* Write to command processor, if not supported by sysfs */
-      if (err) {
-
+      /* Direct write to command processor, if mxt_reset file not found */
+      if (err || mxt->conn->type == E_I2C_DEV) {
+        mxt_info(mxt->ctx, "Sending reset command");
         ret = mxt_write_register(mxt, &write_value, t6_addr + MXT_T6_RESET_OFFSET, 1);
-        mxt_info(mxt->ctx, "Issuing legacy reset command\n");
-
-        if (ret) 
-          mxt_err(mxt->ctx, "Reset issued with possible errors\n");
       }
-
-      if (mxt->mxt_crc.crc_enabled == true) {
+ 
+      /*Re-enable irq processing in sysfs mode */
+      if (mxt->mxt_crc.crc_enabled == true && mxt->conn->type != E_I2C_DEV) {
         err = sysfs_set_debug_irq(mxt, true);
 
         if (err)
-          mxt_dbg(mxt->ctx, "tx_seq_num/debug_irq not available\n");
+          mxt_dbg(mxt->ctx, "debug_irq not available\n");
       }
-    }
-
-    mxt->mxt_crc.reset_triggered = false;
 
     if (reset_time_ms == 0)
         msleep(MXT_SOFT_RESET_TIME);
@@ -666,28 +658,20 @@ static int mxt_send_reset_command(struct mxt_device *mxt, bool bootloader_mode, 
 
     if (mxt->conn->type == E_I2C_DEV && mxt->debug_fs.enabled == true) {
 
-      err = debugfs_get_crc_enabled(mxt, &crc_state);
+      if (mxt->mxt_crc.crc_enabled == true) {
 
-      if (err)
-        mxt_dbg(mxt->ctx, "Failed to read crc_enabled");
-
-      if (crc_state == true) {
         err = debugfs_set_tx_seq_num(mxt, 0x00);
-    
         if (err)
           mxt_dbg(mxt->ctx, "Failed to set tx seq numer\n");
 
-        if (!bootloader_mode) {
-
-          err = debugfs_set_irq(mxt, true);
-
-          if (err)
-            mxt_dbg(mxt->ctx, "Could not disable IRQ");
-
-          mxt->mxt_crc.reset_triggered = false; //Turn IRQ back on after reset
-        }
+        err = debugfs_set_irq(mxt, true);
+        if (err)
+          mxt_dbg(mxt->ctx, "Could not enable IRQ");
       }
     }
+
+    mxt->mxt_crc.reset_triggered = false;
+  }
 
   return ret;
 }

--- a/src/libmaxtouch/sysfs/sysfs_device.c
+++ b/src/libmaxtouch/sysfs/sysfs_device.c
@@ -730,11 +730,11 @@ static int read_sysfs_byte(struct mxt_device *mxt, char *filename,
 }
 
 //******************************************************************************
-/// \brief  Set debug irq state
+/// \brief  Reset chip using mxt_reset sysfs file
 /// \param  mxt Device context
-/// \param  debug_state true = irq enabled, false = irq disabled
+/// \param  none
 /// \return #mxt_rc
-int sysfs_reset_chip(struct mxt_device *mxt, bool reset_chip)
+int sysfs_reset_chip(struct mxt_device *mxt)
 {
   int ret;
 
@@ -744,7 +744,7 @@ int sysfs_reset_chip(struct mxt_device *mxt, bool reset_chip)
     return MXT_ERROR_NO_DEVICE;
   }
 
-    ret = write_boolean_file(mxt, make_path(mxt, "mxt_reset"), reset_chip);
+    ret = write_boolean_file(mxt, make_path(mxt, "mxt_reset"), true);
 
   return ret;
 }

--- a/src/libmaxtouch/sysfs/sysfs_device.h
+++ b/src/libmaxtouch/sysfs/sysfs_device.h
@@ -69,7 +69,7 @@ struct sysfs_device {
   unsigned long mtimestamp;
 };
 
-int sysfs_reset_chip(struct mxt_device *mxt, bool reset_chip);
+int sysfs_reset_chip(struct mxt_device *mxt);
 int sysfs_scan(struct libmaxtouch_ctx *ctx, struct mxt_conn_info **conn);
 int sysfs_spi_scan(struct libmaxtouch_ctx *ctx, struct mxt_conn_info **conn);
 int sysfs_open_i2c(struct mxt_device *mxt);


### PR DESCRIPTION
Integrate reset fix when using I2c-dev interface and debugfs attribute files to reset the chip
Updated branch to latest on master before committing new changes to i2c_dev_fix branch