### PR TITLE
Fix device scan in bootloader mode

### DIFF
--- a/src/mxt-app/bootloader.c
+++ b/src/mxt-app/bootloader.c
@@ -626,13 +626,11 @@ int mxt_flash_firmware(struct libmaxtouch_ctx *ctx,
     }
   }
 
-  if (fw.mxt->conn->type == E_SYSFS_SPI) {
-    ret = mxt_new_device(fw.ctx, fw.conn, &fw.mxt);
-   if (ret) {
+  ret = mxt_new_device(fw.ctx, fw.conn, &fw.mxt);
+    if (ret) {
       mxt_info(fw.ctx, "Could not initialise chip");
       return ret;
     }
-  }
 
   ret = send_frames(&fw);
   if (ret)


### PR DESCRIPTION
Fixed segmentation fault on FW update of device in bootloader mode at bootup